### PR TITLE
feat: add restore_hardclip parameter

### DIFF
--- a/.github/environment.yml
+++ b/.github/environment.yml
@@ -1,0 +1,9 @@
+# for use with conda (https://docs.conda.io/en/latest/miniconda.html):
+# conda env create -f environment.yml
+name: "nextflow-mamba"
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.7
+  - mamba

--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -24,6 +24,9 @@ jobs:
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/
 
+      - name: Install Mamba
+        run: conda install mamba -n base -c conda-forge
+
       - uses: actions/setup-python@v1
         with:
           python-version: 3.7

--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -24,17 +24,9 @@ jobs:
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/
 
-      - name: Install Mamba
-        run: conda install mamba -n base -c conda-forge
-
-      - uses: actions/setup-python@v1
+      - uses: mamba-org/provision-with-micromamba@main
         with:
-          python-version: 3.7
-
-      # - name: Install dependencies
-      #   run: |
-      #     python -m pip install --upgrade pip
-      #     pip install pytest-workflow
+          environment-file: ./.github/environment.yml
 
       - name: Run pipeline with test data
         run: nextflow run main.nf -profile mamba,ci_test

--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -31,10 +31,10 @@ jobs:
         with:
           python-version: 3.7
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install pytest-workflow
+      # - name: Install dependencies
+      #   run: |
+      #     python -m pip install --upgrade pip
+      #     pip install pytest-workflow
 
       - name: Run pipeline with test data
-        run: pytest --tag conda -v --git-aware tests/
+        run: nextflow run main.nf -profile mamba,ci_test

--- a/main.nf
+++ b/main.nf
@@ -16,10 +16,11 @@ def helpMessage(){
         nextflow run lmtani/wf-human-mito [options]
 
     Script Options:
-        --fastq        REGEX     Path to FASTQ directory. Quote is required. Ex: "/path/to/fastqs/*_R{1,2}*.fastq.gz" (optional if alignments provided)
-        --alignments   REGEX     Path to the directory with alignments in BAM or CRAM format. (optional if fastq provided)
-        --reference    FILE      Path to reference (GRCh38). BWA index need to be in same directory (required)
-        --outdir       DIR       Path for output (default: $params.outdir)
+        --fastq             REGEX     Path to FASTQ directory. Quote is required. Ex: "/path/to/fastqs/*_R{1,2}*.fastq.gz" (optional if alignments provided)
+        --alignments        REGEX     Path to the directory with alignments in BAM or CRAM format. (optional if fastq provided)
+        --reference         FILE      Path to reference (GRCh38). BWA index need to be in same directory (required)
+        --outdir            DIR       Path for output (default: $params.outdir)
+        --restore_hardclips BOOLEAN   When true, restores reads and qualities of records with hard-clips containing XB and XQ tags (useful when your inputs are alignments)
     """.stripIndent()
 }
 
@@ -54,8 +55,8 @@ workflow {
     if (params.alignments) {
         alignments = Channel.fromFilePairs("${params.alignments}", glob: true, flat: true)
     }
-
-    separate_mitochondrion(reads, alignments)
+    println(alignments.view())
+    separate_mitochondrion(reads, alignments, params.restore_hardclips)
 
     variant_call(separate_mitochondrion.out)
 

--- a/modules/local/picard/revert_sam.nf
+++ b/modules/local/picard/revert_sam.nf
@@ -10,11 +10,17 @@ process SELECT_MITO_READS {
         path fasta
         path dict
         path index
+        val restore_hardclips
 
     output:
         tuple val(sample_id), path("${sample_id}.mito.unaligned.bam")
 
     script:
+    if (!restore_hardclips) {
+        args = "RESTORE_HARDCLIPS=false"
+    } else {
+        args = ""
+    }
     """
     picard RevertSam \
         INPUT=${bam} \
@@ -24,6 +30,7 @@ process SELECT_MITO_READS {
         ATTRIBUTE_TO_CLEAR=FT \
         ATTRIBUTE_TO_CLEAR=CO \
         SORT_ORDER=queryname \
-        RESTORE_ORIGINAL_QUALITIES=false
+        RESTORE_ORIGINAL_QUALITIES=false \
+        ${args}
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -49,6 +49,15 @@ profiles {
         shifter.enabled        = false
         charliecloud.enabled   = false
     }
+    mamba {
+        params.enable_conda    = true
+        conda.useMamba         = true
+        docker.enabled         = false
+        singularity.enabled    = false
+        podman.enabled         = false
+        shifter.enabled        = false
+        charliecloud.enabled   = false
+    }
     docker {
         docker.enabled         = true
         docker.userEmulation   = true

--- a/nextflow.config
+++ b/nextflow.config
@@ -51,7 +51,7 @@ profiles {
     }
     mamba {
         params.enable_conda    = true
-        conda.useMamba         = true
+        conda.useMicromamba    = true
         docker.enabled         = false
         singularity.enabled    = false
         podman.enabled         = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -10,12 +10,13 @@
 // for further help editing this file.
 
 params {
-    help       = false
-    fastq      = null
-    alignments = null
-    outdir     = 'output'
-    wfversion  = 'v0.1.1'
-    genome     = null
+    help              = false
+    fastq             = null
+    alignments        = null
+    outdir            = 'output'
+    wfversion         = 'v0.1.1'
+    genome            = null
+    restore_hardclips = true
 
     // Output config
     publish_dir_mode = 'copy'

--- a/subworkflows/local/separate_mitochondrion_reads.nf
+++ b/subworkflows/local/separate_mitochondrion_reads.nf
@@ -11,8 +11,9 @@ include { SORT_SAM                   } from '../../modules/local/picard/sort_sam
 
 workflow separate_mitochondrion {
     take:
-        reads       // channel: [ val(sample_id), [ path(fq_r1), path(fq_r2) ] ]
-        alignments  // channel: [ val(sample_id), [ path(bam), path(bai) ] ]
+        reads             // channel: [ val(sample_id), [ path(fq_r1), path(fq_r2) ] ]
+        alignments        // channel: [ val(sample_id), [ path(bam), path(bai) ] ]
+        restore_hardclips // channel: [ val(boolean) ]
     main:
         // Human Reference
         fasta = file("${params.reference}", type:'file', checkIfExists:true)
@@ -32,7 +33,7 @@ workflow separate_mitochondrion {
         mito_reads_ch = SORT_SAM.out.mix(alignments)
         PRINT_READS(mito_reads_ch, fasta, index, dict)
 
-        SELECT_MITO_READS(PRINT_READS.out, fasta, dict, index)
+        SELECT_MITO_READS(PRINT_READS.out, fasta, dict, index, restore_hardclips)
 
     emit:
         SELECT_MITO_READS.out  // channel: [ val(sample_id), ubam ]

--- a/tests/test_pipeline.yml
+++ b/tests/test_pipeline.yml
@@ -17,7 +17,7 @@
 - name: Run all steps in the pipeline with test data using conda profile.
   tags:
     - conda
-  command: nextflow run main.nf -profile conda,ci_test
+  command: nextflow run main.nf -profile mamba,ci_test
   files:
     - path: "test-output/all_samples.csv"
       md5sum: 485508e3cacc4ff1486d484682b616fb


### PR DESCRIPTION
## Description

An error occurs during the "RevertSam" step because of the hard-clipped reads. Probably it is a consequence of the lack of pattern for the use of `XB` and `XQ` flags in the SAM file.

In this pipeline it's only a problem when the user provides alignments (bam/cram) with hard clipped reads without _XB/XQ_ flags.

This PR adds a parameter to make _picard RevertSam_ process not restore bases and qualities from the hard-clipped part of the reads.

Example of what is a hard-clipped read in the alignment (SAM):

```
read_id 2193    chr20   64513   0       36M65H  chr21   10716407        0       CCACTCCGCTCCACTCCTCTCCATTCCACTCCACTC    JAFJJJJFJJJJJF-JA-AAJFFJ<JAAAFFF<F<F
```

The CIGAR `36M65H` tells us that initially, this read presented 101bp, 36 matches, and 65 hard-clipped bases. The file only stores the matches in this case.

Using this flag (`--restore_hardclip` false) you'll lose some raw data from your sequencing experiment. For example, reads mapping near to the "ends" of the mitochondria genome could be hard-clipped and would lose this data that could be useful when aligning them to the shifted version of the mitochondrial genome, where the hard-clipped portion could also be aligned.


Having saying that, the suggestion is: use it only if you have the problem reported in #10 .

```java
  To get help, see http://broadinstitute.github.io/picard/index.html#GettingHelp
  Exception in thread "main" htsjdk.samtools.SAMException: Value for tag XQ is not a String: class java.lang.Integer
  	at htsjdk.samtools.SAMRecord.getStringAttribute(SAMRecord.java:1342)
  	at picard.sam.RevertSam.revertSamRecord(RevertSam.java:409)
  	at picard.sam.RevertSam.doWork(RevertSam.java:315)
  	at picard.cmdline.CommandLineProgram.instanceMain(CommandLineProgram.java:308)
  	at picard.cmdline.PicardCommandLine.instanceMain(PicardCommandLine.java:103)
  	at picard.cmdline.PicardCommandLine.main(PicardCommandLine.java:113)
```